### PR TITLE
Correct DI configuration

### DIFF
--- a/public_html/Application.cfc
+++ b/public_html/Application.cfc
@@ -29,7 +29,7 @@ component extends=frameworkone {
 		SESOmitIndex = true,
 		reloadApplicationOnEveryRequest = true,
 		unhandledPaths = "/css,/fonts,/images,/js",
-		diEngine = "app.framework.ioc",
+		diComponent = "app.framework.ioc",
 		diLocations = "/app/model,/app/controllers",
 		diConfig = this.diConfig
 	};
@@ -39,7 +39,5 @@ component extends=frameworkone {
 	};
 
 	function setupApplication() {
-		var beanFactory = new "#variables.framework.diEngine#"( "/app/model", this.diConfig );
-		setBeanFactory( beanFactory );
 	}
 }


### PR DESCRIPTION
Set `diComponent` to `"app.framework.ioc"` -- not `diEngine` (which tells FW/1 which _type_ of engine to use -- `diComponent` tells FW/1 where to find that CFC).

Removed bean factory setup since it is not needed.
